### PR TITLE
Adding override for ingress paths and WEBAPP_CONTEXT

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart for guacamole
 name: guacamole
-version: 0.2.0
+version: 0.2.1

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: "{{ .Values.guacd.service.port }}"
             - name: GUACAMOLE_HOME
               value: "/etc/guacamole"
+            - name: WEBAPP_CONTEXT
+              value: "{{ .Values.guacamole.webapp_context }}"
           ports:
             - name: http
               containerPort: 8080

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -30,9 +30,13 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
+        {{- if len ($.Values.guacamole.ingress.paths) }}
+          {{- "\n" }}{{ tpl (toYaml $.Values.guacamole.ingress.paths | indent 10) $ }}
+        {{- else }}
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,15 @@ guacamole:
       kubernetes.io/tls-acme: "true"
       kubernetes.io/ingress.class: nginx
       certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    paths: []
+    #  - backend:
+    #      serviceName: ssl-redirect
+    #      servicePort: use-annotation
+    #  - backend:
+    #      serviceName: >-
+    #        {{ include "guacamole.fullname" . }}
+    #      # Don't use string here, use only integer value!
+    #      servicePort: 443
     path: /
     hosts:
       - guacamole.corp.justin-tech.com
@@ -74,6 +83,9 @@ guacamole:
   tolerations: []
 
   affinity: {}
+
+  # Change this to ROOT to get rid of the /guacamole prefix
+  webapp_context: guacamole
 
 guacd:
   replicaCount: 1


### PR DESCRIPTION
This PR is adding two features:

1) Possibility to override the default Ingress paths with a new block of paths defined as YAML data structure. This allows to configure the Ingress resource to work with the AWS ALB Ingress Controller to automatically [redirect HTTP traffic to HTTPS](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/) on the load balancer.

2) Possibility to override the Tomcat's `WEBAPP_CONTEXT` which can be used to change the default Guacamole URL prefix (`/guacamole`) or even remove the prefix all together by setting the value to `ROOT`.